### PR TITLE
[BUGFIX] Add missing renderType for TCA select

### DIFF
--- a/Configuration/TCA/tx_contagged_terms.php
+++ b/Configuration/TCA/tx_contagged_terms.php
@@ -85,6 +85,7 @@ return [
             'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.l18n_parent',
             'config' => [
                 'type' => 'select',
+                'renderType' => 'selectSingle',
                 'items' => [
                     ['', 0],
                 ],


### PR DESCRIPTION
The TCA for tx_contagged_terms is missing the renderType configuration for the l18n_parent field.
The renderType configuration is necessary for every type=select TCA field to work with TYPO3 7.6.